### PR TITLE
Emulio#47

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     ext.kotlinVersion = '1.2.10'
 
     dependencies {
+        classpath 'org.junit.platform:junit-platform-gradle-plugin:1.1.0-M2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
         compile "com.badlogicgames.gdx:gdx-controllers:$gdxVersion"
         compile "com.badlogicgames.gdx:gdx-freetype:$gdxVersion"
+        compile "com.github.czyzby:gdx-lml-vis:1.9.1.9.6"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,50 @@ project(":core") {
     }
 }
 
+project(":tests") {
+    apply plugin: 'org.junit.platform.gradle.plugin'
+    apply plugin: 'kotlin'
+
+    sourceSets.test.java.srcDirs = ["src/"]
+
+    task createTestResources << {
+        def mockMakerFile = new File("$projectDir/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker")
+        if (System.env.MOCK_MAKER != null) {
+            logger.info("Using MockMaker ${System.env.MOCK_MAKER}")
+            mockMakerFile.parentFile.mkdirs()
+            mockMakerFile.createNewFile()
+            mockMakerFile.write(System.env.MOCK_MAKER)
+        } else {
+            logger.info("Using default MockMaker")
+        }
+    }
+
+    dependencies {
+        compile project(":core")
+
+        compile "junit:junit:5.+"
+
+        compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+        compile "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
+
+        compile "com.badlogicgames.gdx:gdx-backend-headless:$gdxVersion"
+        compile "com.badlogicgames.gdx:gdx:$gdxVersion"
+
+
+
+        testCompile 'junit:junit:5.+'
+        testCompile("org.junit.jupiter:junit-jupiter-api:5.1.0-M2")
+        testRuntime("org.junit.jupiter:junit-jupiter-engine:5.1.0-M2")
+
+        testCompile "com.badlogicgames.gdx:gdx-backend-headless:$gdxVersion"
+        testCompile "com.badlogicgames.gdx:gdx:$gdxVersion"
+        testCompile "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
+
+        testCompile "org.mockito:mockito-core:2.+"
+
+    }
+}
+
 tasks.eclipse.doLast {
     delete ".project"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -96,8 +96,6 @@ project(":tests") {
         compile "com.badlogicgames.gdx:gdx-backend-headless:$gdxVersion"
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
 
-
-
         testCompile 'junit:junit:5.+'
         testCompile("org.junit.jupiter:junit-jupiter-api:5.1.0-M2")
         testRuntime("org.junit.jupiter:junit-jupiter-engine:5.1.0-M2")
@@ -105,9 +103,7 @@ project(":tests") {
         testCompile "com.badlogicgames.gdx:gdx-backend-headless:$gdxVersion"
         testCompile "com.badlogicgames.gdx:gdx:$gdxVersion"
         testCompile "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
-
         testCompile "org.mockito:mockito-core:2.+"
-
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,7 @@ project(":tests") {
         testCompile "com.badlogicgames.gdx:gdx:$gdxVersion"
         testCompile "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
         testCompile "org.mockito:mockito-core:2.+"
+        testCompile "com.nhaarman:mockito-kotlin:1.5.0"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,6 @@ project(":tests") {
         testCompile "com.badlogicgames.gdx:gdx-backend-headless:$gdxVersion"
         testCompile "com.badlogicgames.gdx:gdx:$gdxVersion"
         testCompile "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
-        testCompile "org.mockito:mockito-core:2.+"
         testCompile "com.nhaarman:mockito-kotlin:1.5.0"
     }
 }

--- a/core/assets/skin/emulio-skin.atlas
+++ b/core/assets/skin/emulio-skin.atlas
@@ -649,6 +649,13 @@ white
   orig: 1, 1
   offset: 0, 0
   index: -1
+default
+  rotate: false
+  xy: 867, 872
+  size: 1, 1
+  orig: 1, 1
+  offset: 0, 0
+  index: -1
 window
   rotate: false
   xy: 629, 802

--- a/core/assets/templates/ScraperWindow.lml
+++ b/core/assets/templates/ScraperWindow.lml
@@ -1,0 +1,3 @@
+<window title="Hello World" titleAlign="center">
+    Teste
+</window>

--- a/core/assets/templates/ScraperWindow.lml
+++ b/core/assets/templates/ScraperWindow.lml
@@ -1,3 +1,6 @@
-<window title="Hello World" titleAlign="center">
-    Teste
+<:importStyleSheet>templates/ScrapperWindow.lss</:importStyleSheet>
+<window id="scrapperWindow">
+    <container>
+        <image id="scraperPlatformImage" scaling="fill" />
+    </container>
 </window>

--- a/core/assets/templates/ScraperWindow.lml
+++ b/core/assets/templates/ScraperWindow.lml
@@ -1,6 +1,6 @@
 <:importStyleSheet>templates/ScrapperWindow.lss</:importStyleSheet>
 <window id="scrapperWindow">
     <container>
-        <image id="scraperPlatformImage" scaling="fill" />
+        <image id="scraperPlatformImage"/>
     </container>
 </window>

--- a/core/assets/templates/ScrapperWindow.lss
+++ b/core/assets/templates/ScrapperWindow.lss
@@ -1,0 +1,12 @@
+window {
+    titleAlign: center;
+}
+
+container {
+    width: 670;
+    height: 400;
+}
+
+image {
+    scaling: fill;
+}

--- a/core/assets/templates/ScrapperWindow.lss
+++ b/core/assets/templates/ScrapperWindow.lss
@@ -8,5 +8,5 @@ container {
 }
 
 image {
-    scaling: fill;
+    scaling: fit;
 }

--- a/core/src/com/github/emulio/model/theme/Theme.kt
+++ b/core/src/com/github/emulio/model/theme/Theme.kt
@@ -1,5 +1,10 @@
 package com.github.emulio.model.theme
 
+import com.badlogic.gdx.files.FileHandle
+import com.badlogic.gdx.graphics.Texture
+import com.badlogic.gdx.graphics.g2d.TextureRegion
+import com.badlogic.gdx.scenes.scene2d.utils.Drawable
+import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable
 import com.github.emulio.model.Platform
 import java.io.File
 import java.util.*
@@ -14,7 +19,16 @@ class Theme {
 	override fun toString(): String {
 		return "Theme(formatVersion=$formatVersion, includeTheme=$includeTheme, views=$views)"
 	}
-	
+
+	fun getDrawableFromPlatformTheme(): Drawable {
+		val systemView = checkNotNull(this.findView("system"), { "System tag of theme ${this.platform?.platformName} not found. please check your theme files." })
+		val logo = systemView.findViewItem("logo")!! as ViewImage
+		val texture = Texture(FileHandle(logo.path), true)
+		texture.setFilter(Texture.TextureFilter.MipMap, Texture.TextureFilter.MipMap)
+
+		return TextureRegionDrawable(TextureRegion(texture))
+	}
+
 	fun findView(name: String): View? {
 		views?.forEach { view ->
 			if (view.name == name) {

--- a/core/src/com/github/emulio/ui/input/EmlGDXList.kt
+++ b/core/src/com/github/emulio/ui/input/EmlGDXList.kt
@@ -1,0 +1,40 @@
+package com.github.emulio.ui.input
+
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.graphics.g2d.BitmapFont
+import com.badlogic.gdx.graphics.g2d.TextureRegion
+import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable
+import com.github.emulio.ui.screens.createColorTexture
+
+class EmlGDXList<T>(list: List<T>, mainFont: BitmapFont?, listWidth: Float, getDescription: (T) -> String) : EmlList {
+    private val list = list
+
+    val listView = com.badlogic.gdx.scenes.scene2d.ui.List<String>(com.badlogic.gdx.scenes.scene2d.ui.List.ListStyle().apply {
+        font = mainFont
+        fontColorSelected = Color.WHITE
+        fontColorUnselected = Color(0x878787FF.toInt())
+        val selectorTexture = createColorTexture(0x878787FF.toInt())
+        selection = TextureRegionDrawable(TextureRegion(selectorTexture))
+
+    })
+
+    init {
+        this.listView.apply {
+            val descriptionsArray = list.map(getDescription).toTypedArray()
+            setItems(com.badlogic.gdx.utils.Array(descriptionsArray))
+
+            width = listWidth
+            height = 100f
+            selectedIndex = 0
+        }
+    }
+
+    override val size: Int
+        get() = list.size
+
+    override var selectedIndex: Int
+        get() = listView.selectedIndex
+        set(value) {
+            listView.selectedIndex = value
+        }
+}

--- a/core/src/com/github/emulio/ui/input/EmlGDXScroll.kt
+++ b/core/src/com/github/emulio/ui/input/EmlGDXScroll.kt
@@ -1,0 +1,22 @@
+package com.github.emulio.ui.input
+
+import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane
+
+class EmlGDXScroll(listView: com.badlogic.gdx.scenes.scene2d.ui.List<*>): EmlScroll {
+    private val list = listView
+    val scroll = ScrollPane(listView, ScrollPane.ScrollPaneStyle()).apply {
+        setFlickScroll(true)
+        setScrollBarPositions(false, true)
+        setScrollingDisabled(true, false)
+        setSmoothScrolling(true)
+
+        isTransform = true
+    }
+
+    override val size: Int
+        get() = (scroll.height/list.itemHeight).toInt()
+
+    override fun setScrollTop(top: Int){
+        scroll.scrollY = top * list.itemHeight
+    }
+}

--- a/core/src/com/github/emulio/ui/input/EmlScrollList.kt
+++ b/core/src/com/github/emulio/ui/input/EmlScrollList.kt
@@ -1,0 +1,44 @@
+package com.github.emulio.ui.input
+
+class EmlScrollList<T>(scroll: EmlScroll, itemsList: EmlList)
+{
+    private val list = itemsList
+    private val scroll = scroll
+
+    fun scroll(amount: Int) {
+        val nextIndex = (this.list.selectedIndex + amount)
+
+        list.selectedIndex = nextIndex.coerceIn(0 until  list.size.coerceAtLeast(1))
+
+        val scrollTopIndex = calcScrollTopIndex(list.selectedIndex,scroll.size)
+        scroll.setScrollTop(scrollTopIndex)
+    }
+
+    private fun calcScrollTopIndex(selectionIndex: Int, scrollSize: Int): Int {
+        val scrollTopMax = (list.size - scrollSize).coerceAtLeast(0)
+
+        val scrollCenterOffset = (scrollSize/2).coerceAtLeast(0)
+        val scrollCenterMax =  (list.size - scrollCenterOffset).coerceAtLeast(0)
+
+        if (selectionIndex < scrollCenterOffset) {
+            return 0
+        }
+
+        if (selectionIndex > scrollCenterMax) {
+            return scrollTopMax
+        }
+
+        return (selectionIndex - scrollCenterOffset).coerceAtLeast(0)
+    }
+}
+
+interface EmlList {
+    var selectedIndex: Int
+    val size: Int
+}
+
+interface EmlScroll {
+    val size: Int
+    fun setScrollTop(top: Int)
+}
+

--- a/core/src/com/github/emulio/ui/input/EmlScrollList.kt
+++ b/core/src/com/github/emulio/ui/input/EmlScrollList.kt
@@ -5,6 +5,8 @@ class EmlScrollList<T>(scroll: EmlScroll, itemsList: EmlList)
     private val list = itemsList
     private val scroll = scroll
 
+    val selectedIndex: Int get() = list.selectedIndex
+
     fun scroll(amount: Int) {
         val nextIndex = (this.list.selectedIndex + amount)
 

--- a/core/src/com/github/emulio/ui/input/ScraperWindow.kt
+++ b/core/src/com/github/emulio/ui/input/ScraperWindow.kt
@@ -1,0 +1,19 @@
+package com.github.emulio.ui.input
+
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.ui.Skin
+import com.github.czyzby.lml.vis.util.VisLml
+import com.kotcrab.vis.ui.VisUI
+
+class ScraperWindow(skin: Skin) {
+
+    val actors: com.badlogic.gdx.utils.Array<Actor>
+
+    init {
+        VisUI.load()
+        val parser = VisLml.parser().skin(skin).build()
+
+        actors = parser.parseTemplate(Gdx.files.internal("templates/ScraperWindow.lml"))
+    }
+}

--- a/core/src/com/github/emulio/ui/input/ScraperWindow.kt
+++ b/core/src/com/github/emulio/ui/input/ScraperWindow.kt
@@ -11,13 +11,11 @@ import com.badlogic.gdx.scenes.scene2d.ui.Skin
 import com.badlogic.gdx.scenes.scene2d.ui.Window
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable
-import com.badlogic.gdx.utils.Scaling
 import com.github.czyzby.lml.annotation.LmlActor
 import com.github.czyzby.lml.parser.impl.AbstractLmlView
 import com.github.czyzby.lml.vis.util.VisLml
 import com.github.emulio.model.Platform
 import com.github.emulio.model.theme.Theme
-import com.github.emulio.model.theme.View
 import com.github.emulio.model.theme.ViewImage
 import com.kotcrab.vis.ui.VisUI
 
@@ -45,19 +43,9 @@ class ScraperView(stage: Stage): AbstractLmlView(stage) {
         return  "scraperViewId"
     }
 
-    fun setPlatform(platform: Platform, theme: Theme){
-
-        platformImage.name = platform.platformName
-        platformImage.drawable = getDrawableFromPlatformTheme(platform, theme)
-        window.titleLabel.setText(platform.name)
-    }
-
-    private fun getDrawableFromPlatformTheme(platform: Platform, theme: Theme): Drawable {
-        val systemView = checkNotNull(theme.findView("system"), { "System tag of theme ${platform.platformName} not found. please check your theme files." })
-        val logo = systemView.findViewItem("logo")!! as ViewImage
-        val texture = Texture(FileHandle(logo.path), true)
-        texture.setFilter(Texture.TextureFilter.MipMap, Texture.TextureFilter.MipMap)
-
-        return TextureRegionDrawable(TextureRegion(texture))
+    fun updatePlatformTheme(theme: Theme){
+        platformImage.name = theme.platform?.platformName
+        platformImage.drawable = theme.getDrawableFromPlatformTheme()
+        window.titleLabel.setText(theme.platform?.name)
     }
 }

--- a/core/src/com/github/emulio/ui/input/ScraperWindow.kt
+++ b/core/src/com/github/emulio/ui/input/ScraperWindow.kt
@@ -1,15 +1,24 @@
 package com.github.emulio.ui.input
 
 import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.files.FileHandle
+import com.badlogic.gdx.graphics.Texture
+import com.badlogic.gdx.graphics.g2d.TextureRegion
 import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.scenes.scene2d.ui.Skin
 import com.badlogic.gdx.scenes.scene2d.ui.Window
+import com.badlogic.gdx.scenes.scene2d.utils.Drawable
+import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable
+import com.badlogic.gdx.utils.Scaling
 import com.github.czyzby.lml.annotation.LmlActor
 import com.github.czyzby.lml.parser.impl.AbstractLmlView
 import com.github.czyzby.lml.vis.util.VisLml
 import com.github.emulio.model.Platform
+import com.github.emulio.model.theme.Theme
+import com.github.emulio.model.theme.View
+import com.github.emulio.model.theme.ViewImage
 import com.kotcrab.vis.ui.VisUI
 
 class ScraperWindow(stage: Stage, skin: Skin) {
@@ -36,8 +45,19 @@ class ScraperView(stage: Stage): AbstractLmlView(stage) {
         return  "scraperViewId"
     }
 
-    fun setPlatform(platform: Platform){
-        window.titleLabel.setText(platform.name)
+    fun setPlatform(platform: Platform, theme: Theme){
+
         platformImage.name = platform.platformName
+        platformImage.drawable = getDrawableFromPlatformTheme(platform, theme)
+        window.titleLabel.setText(platform.name)
+    }
+
+    private fun getDrawableFromPlatformTheme(platform: Platform, theme: Theme): Drawable {
+        val systemView = checkNotNull(theme.findView("system"), { "System tag of theme ${platform.platformName} not found. please check your theme files." })
+        val logo = systemView.findViewItem("logo")!! as ViewImage
+        val texture = Texture(FileHandle(logo.path), true)
+        texture.setFilter(Texture.TextureFilter.MipMap, Texture.TextureFilter.MipMap)
+
+        return TextureRegionDrawable(TextureRegion(texture))
     }
 }

--- a/core/src/com/github/emulio/ui/input/ScraperWindow.kt
+++ b/core/src/com/github/emulio/ui/input/ScraperWindow.kt
@@ -2,18 +2,42 @@ package com.github.emulio.ui.input
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.Stage
+import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.scenes.scene2d.ui.Skin
+import com.badlogic.gdx.scenes.scene2d.ui.Window
+import com.github.czyzby.lml.annotation.LmlActor
+import com.github.czyzby.lml.parser.impl.AbstractLmlView
 import com.github.czyzby.lml.vis.util.VisLml
+import com.github.emulio.model.Platform
 import com.kotcrab.vis.ui.VisUI
 
-class ScraperWindow(skin: Skin) {
+class ScraperWindow(stage: Stage, skin: Skin) {
 
     val actors: com.badlogic.gdx.utils.Array<Actor>
+    val view: ScraperView
 
     init {
         VisUI.load()
         val parser = VisLml.parser().skin(skin).build()
 
-        actors = parser.parseTemplate(Gdx.files.internal("templates/ScraperWindow.lml"))
+        val template = Gdx.files.internal("templates/ScraperWindow.lml")
+        view = ScraperView(stage)
+
+        actors = parser.createView(view, template)
+    }
+}
+
+class ScraperView(stage: Stage): AbstractLmlView(stage) {
+    @LmlActor("scraperPlatformImage") lateinit var platformImage: Image
+    @LmlActor("scrapperWindow") lateinit var window: Window
+
+    override fun getViewId(): String {
+        return  "scraperViewId"
+    }
+
+    fun setPlatform(platform: Platform){
+        window.titleLabel.setText(platform.name)
+        platformImage.name = platform.platformName
     }
 }

--- a/core/src/com/github/emulio/ui/screens/ScraperScreen.kt
+++ b/core/src/com/github/emulio/ui/screens/ScraperScreen.kt
@@ -210,7 +210,7 @@ class ScraperScreen(emulio: Emulio, private val backCallback: () -> EmulioScreen
         val selectorTexture = createColorTexture(0x878787FF.toInt())
         val lightTexture = createColorTexture(0xADADADFF.toInt())
 
-        val platformDetail = Window("alo mundo", emulio.skin, "naked").apply {
+//        val platformDetail = Window("alo mundo", emulio.skin, "naked").apply {
 //            pad(5f)
 
 
@@ -233,10 +233,13 @@ class ScraperScreen(emulio: Emulio, private val backCallback: () -> EmulioScreen
 //            add(Label("Missing:", Label.LabelStyle(mainFont, Color.DARK_GRAY).apply {
 //                background = TextureRegionDrawable(TextureRegion(lightTexture))
 //            })).expand().fillX()
-        }
+//        }
 
 //        platformDetail.background = TextureRegionDrawable(TextureRegion(selectorTexture))
-        root.add(platformDetail).expand().fillX()
+
+        ScraperWindow(emulio.skin).actors.forEach { actor ->
+            root.add(actor)
+        }
     }
 
 

--- a/core/src/com/github/emulio/ui/screens/ScraperScreen.kt
+++ b/core/src/com/github/emulio/ui/screens/ScraperScreen.kt
@@ -41,6 +41,7 @@ class ScraperScreen(emulio: Emulio, private val backCallback: () -> EmulioScreen
     private val root: Table
 
     private lateinit var platformsScrollList: EmlScrollList<Platform>
+    private lateinit var scraperWindow: ScraperWindow
 
     init {
         Gdx.input.inputProcessor = inputController
@@ -203,7 +204,7 @@ class ScraperScreen(emulio: Emulio, private val backCallback: () -> EmulioScreen
         }
         val platformsGDXScroll = EmlGDXScroll(platformsGDXList.listView)
 
-        root.add(platformsGDXScroll.scroll).expand().fill()
+        root.add(platformsGDXScroll.scroll)
 
         platformsScrollList = EmlScrollList(platformsGDXScroll, platformsGDXList)
 
@@ -237,11 +238,17 @@ class ScraperScreen(emulio: Emulio, private val backCallback: () -> EmulioScreen
 
 //        platformDetail.background = TextureRegionDrawable(TextureRegion(selectorTexture))
 
-        ScraperWindow(emulio.skin).actors.forEach { actor ->
+        scraperWindow = ScraperWindow(stage,emulio.skin)
+        scraperWindow.actors.forEach { actor ->
             root.add(actor)
         }
+        updateScraperWindow()
     }
 
+    private fun updateScraperWindow() {
+        val platform = emulio.platforms[platformsScrollList.selectedIndex]
+        scraperWindow.view.setPlatform(platform)
+    }
 
     private fun obtainNextIndex(currentIndex: Int): Int {
         return if (currentIndex == options.size - 1) {
@@ -365,11 +372,15 @@ class ScraperScreen(emulio: Emulio, private val backCallback: () -> EmulioScreen
     override fun onUpButton(input: InputConfig) {
         updateHelp(input)
         platformsScrollList.scroll(-1)
+
+        updateScraperWindow()
     }
 
     override fun onDownButton(input: InputConfig) {
         updateHelp(input)
         platformsScrollList.scroll(1)
+
+        updateScraperWindow()
     }
 
     override fun onLeftButton(input: InputConfig) {

--- a/core/src/com/github/emulio/ui/screens/ScraperScreen.kt
+++ b/core/src/com/github/emulio/ui/screens/ScraperScreen.kt
@@ -42,6 +42,8 @@ class ScraperScreen(emulio: Emulio, private val backCallback: () -> EmulioScreen
     private val selector: Image
     private val root: Table
 
+    private lateinit var platformsList: com.badlogic.gdx.scenes.scene2d.ui.List<String>
+
     init {
         Gdx.input.inputProcessor = inputController
 
@@ -200,7 +202,7 @@ class ScraperScreen(emulio: Emulio, private val backCallback: () -> EmulioScreen
     private fun buildScrapPlatformPage(mainFont: BitmapFont?, emulio: Emulio) {
         root.clearChildren()
 
-        val platformsList = com.badlogic.gdx.scenes.scene2d.ui.List<String>(com.badlogic.gdx.scenes.scene2d.ui.List.ListStyle().apply {
+        platformsList = com.badlogic.gdx.scenes.scene2d.ui.List<String>(com.badlogic.gdx.scenes.scene2d.ui.List.ListStyle().apply {
             font = mainFont
             fontColorSelected = Color.WHITE
             fontColorUnselected = Color(0x878787FF.toInt())
@@ -392,10 +394,12 @@ class ScraperScreen(emulio: Emulio, private val backCallback: () -> EmulioScreen
 
     override fun onUpButton(input: InputConfig) {
         updateHelp(input)
+        scrollPlatforms(-1)
     }
 
     override fun onDownButton(input: InputConfig) {
         updateHelp(input)
+        scrollPlatforms(1)
     }
 
     override fun onLeftButton(input: InputConfig) {
@@ -431,5 +435,13 @@ class ScraperScreen(emulio: Emulio, private val backCallback: () -> EmulioScreen
     override fun onExitButton(input: InputConfig) {
         updateHelp(input)
         showCloseDialog()
+    }
+
+    private fun scrollPlatforms(amount: Int) {
+        val nextIndex = platformsList.selectedIndex + amount
+
+        if (nextIndex in 0 until  platformsList.items.size){
+            platformsList.selectedIndex = nextIndex
+        }
     }
 }

--- a/core/src/com/github/emulio/ui/screens/ScraperScreen.kt
+++ b/core/src/com/github/emulio/ui/screens/ScraperScreen.kt
@@ -247,7 +247,7 @@ class ScraperScreen(emulio: Emulio, private val backCallback: () -> EmulioScreen
 
     private fun updateScraperWindow() {
         val platform = emulio.platforms[platformsScrollList.selectedIndex]
-        scraperWindow.view.setPlatform(platform, emulio.theme[platform]!!)
+        scraperWindow.view.updatePlatformTheme(emulio.theme[platform]!!)
     }
 
     private fun obtainNextIndex(currentIndex: Int): Int {

--- a/core/src/com/github/emulio/ui/screens/ScraperScreen.kt
+++ b/core/src/com/github/emulio/ui/screens/ScraperScreen.kt
@@ -247,7 +247,7 @@ class ScraperScreen(emulio: Emulio, private val backCallback: () -> EmulioScreen
 
     private fun updateScraperWindow() {
         val platform = emulio.platforms[platformsScrollList.selectedIndex]
-        scraperWindow.view.setPlatform(platform)
+        scraperWindow.view.setPlatform(platform, emulio.theme[platform]!!)
     }
 
     private fun obtainNextIndex(currentIndex: Int): Int {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include 'desktop', 'core'
+include 'desktop', 'core', 'tests'

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -1,0 +1,22 @@
+
+
+apply plugin: "java"
+
+sourceCompatibility = 1.6
+[compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
+
+
+
+sourceSets {
+	test {
+        java {
+            srcDir 'src'
+        }
+    }
+    
+    
+}
+
+eclipse.project {
+    name = appName + "-tests"
+}

--- a/tests/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/tests/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/tests/src/com/github/emulio/ui/input/EmlScrollListTest.kt
+++ b/tests/src/com/github/emulio/ui/input/EmlScrollListTest.kt
@@ -1,18 +1,20 @@
 package com.github.emulio.ui.input
 
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.*
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
 
 
 internal class EmlScrollListTest {
 
     @Test
     fun Scroll_by_zero_should_stay_at_same_index() {
-        val mockEmlList = mock(EmlList::class.java)
-        val emlScroll = mock(EmlScroll::class.java)
-        `when`(mockEmlList.size).thenReturn(7)
-        `when`(mockEmlList.selectedIndex).thenReturn(5)
-        `when`(emlScroll.size).thenReturn(3)
+        val mockEmlList: EmlList = mock()
+        val emlScroll: EmlScroll = mock()
+        whenever(mockEmlList.size).thenReturn(7)
+        whenever(mockEmlList.selectedIndex).thenReturn(5)
+        whenever(emlScroll.size).thenReturn(3)
         val emlScrolList = EmlScrollList<String>(emlScroll, mockEmlList)
 
         emlScrolList.scroll(0)
@@ -22,11 +24,11 @@ internal class EmlScrollListTest {
 
     @Test
     fun Selecting_beyond_list_start_stops_at_start() {
-        val mockEmlList = mock(EmlList::class.java)
-        val emlScroll = mock(EmlScroll::class.java)
-        `when`(mockEmlList.size).thenReturn(7)
-        `when`(mockEmlList.selectedIndex).thenReturn(5)
-        `when`(emlScroll.size).thenReturn(3)
+        val mockEmlList: EmlList = mock()
+        val emlScroll: EmlScroll = mock()
+        whenever(mockEmlList.size).thenReturn(7)
+        whenever(mockEmlList.selectedIndex).thenReturn(5)
+        whenever(emlScroll.size).thenReturn(3)
         val emlScrolList = EmlScrollList<String>(emlScroll, mockEmlList)
 
         emlScrolList.scroll(-20)
@@ -36,11 +38,11 @@ internal class EmlScrollListTest {
 
     @Test
     fun Selecting_beyond_list_end_stops_at_end() {
-        val mockEmlList = mock(EmlList::class.java)
-        val emlScroll = mock(EmlScroll::class.java)
-        `when`(mockEmlList.size).thenReturn(7)
-        `when`(mockEmlList.selectedIndex).thenReturn(5)
-        `when`(emlScroll.size).thenReturn(3)
+        val mockEmlList: EmlList = mock()
+        val emlScroll: EmlScroll = mock()
+        whenever(mockEmlList.size).thenReturn(7)
+        whenever(mockEmlList.selectedIndex).thenReturn(5)
+        whenever(emlScroll.size).thenReturn(3)
         val emlScrolList = EmlScrollList<String>(emlScroll, mockEmlList)
 
         emlScrolList.scroll(20)
@@ -50,11 +52,11 @@ internal class EmlScrollListTest {
 
     @Test
     fun Scrolling_by_less_than_half_the_does_not_move_the_scroll() {
-        val list = mock(EmlList::class.java)
-        val mockScroll = mock(EmlScroll::class.java)
-        `when`(list.size).thenReturn(7)
-        `when`(list.selectedIndex).thenReturn(1)
-        `when`(mockScroll.size).thenReturn(3)
+        val list: EmlList = mock()
+        val mockScroll: EmlScroll = mock()
+        whenever(list.size).thenReturn(7)
+        whenever(list.selectedIndex).thenReturn(1)
+        whenever(mockScroll.size).thenReturn(3)
         val emlScrolList = EmlScrollList<String>(mockScroll, list)
 
         emlScrolList.scroll(1)
@@ -64,11 +66,11 @@ internal class EmlScrollListTest {
 
     @Test
     fun Scrolling_by_more_than_half_the_scroll_size_moves_scroll() {
-        val list = mock(EmlList::class.java)
-        val mockScroll = mock(EmlScroll::class.java)
-        `when`(list.size).thenReturn(7)
-        `when`(list.selectedIndex).thenReturn(2)
-        `when`(mockScroll.size).thenReturn(3)
+        val list: EmlList = mock()
+        val mockScroll: EmlScroll = mock()
+        whenever(list.size).thenReturn(7)
+        whenever(list.selectedIndex).thenReturn(2)
+        whenever(mockScroll.size).thenReturn(3)
 
         val emlScrolList = EmlScrollList<String>(mockScroll, list)
         emlScrolList.scroll(2)
@@ -78,11 +80,11 @@ internal class EmlScrollListTest {
 
     @Test
     fun Scrolling_to_the_middle_moves_the_scroll() {
-        val list = mock(EmlList::class.java)
-        val mockScroll = mock(EmlScroll::class.java)
-        `when`(list.size).thenReturn(7)
-        `when`(list.selectedIndex).thenReturn(4)
-        `when`(mockScroll.size).thenReturn(3)
+        val list: EmlList = mock()
+        val mockScroll: EmlScroll = mock()
+        whenever(list.size).thenReturn(7)
+        whenever(list.selectedIndex).thenReturn(4)
+        whenever(mockScroll.size).thenReturn(3)
 
         val emlScrolList = EmlScrollList<String>(mockScroll, list)
         emlScrolList.scroll(4)
@@ -92,11 +94,11 @@ internal class EmlScrollListTest {
 
     @Test
     fun Scrolling_to_the_end_stops_the_scroll_at_the_end() {
-        val list = mock(EmlList::class.java)
-        val mockScroll = mock(EmlScroll::class.java)
-        `when`(list.size).thenReturn(7)
-        `when`(list.selectedIndex).thenReturn(7)
-        `when`(mockScroll.size).thenReturn(3)
+        val list: EmlList = mock()
+        val mockScroll: EmlScroll = mock()
+        whenever(list.size).thenReturn(7)
+        whenever(list.selectedIndex).thenReturn(7)
+        whenever(mockScroll.size).thenReturn(3)
 
         val emlScrolList = EmlScrollList<String>(mockScroll, list)
         emlScrolList.scroll(7)
@@ -106,11 +108,11 @@ internal class EmlScrollListTest {
 
     @Test
     fun Empty_list_does_not_scroll() {
-        val list = mock(EmlList::class.java)
-        val mockScroll = mock(EmlScroll::class.java)
-        `when`(list.size).thenReturn(0)
-        `when`(list.selectedIndex).thenReturn(7)
-        `when`(mockScroll.size).thenReturn(3)
+        val list: EmlList = mock()
+        val mockScroll: EmlScroll = mock()
+        whenever(list.size).thenReturn(0)
+        whenever(list.selectedIndex).thenReturn(7)
+        whenever(mockScroll.size).thenReturn(3)
 
         val emlScrolList = EmlScrollList<String>(mockScroll, list)
         emlScrolList.scroll(7)
@@ -120,11 +122,11 @@ internal class EmlScrollListTest {
 
     @Test
     fun Scroll_greater_than_list_does_not_scroll() {
-        val list = mock(EmlList::class.java)
-        val mockScroll = mock(EmlScroll::class.java)
-        `when`(list.size).thenReturn(10)
-        `when`(list.selectedIndex).thenReturn(8)
-        `when`(mockScroll.size).thenReturn(11)
+        val list: EmlList = mock()
+        val mockScroll: EmlScroll = mock()
+        whenever(list.size).thenReturn(10)
+        whenever(list.selectedIndex).thenReturn(8)
+        whenever(mockScroll.size).thenReturn(11)
 
         val emlScrolList = EmlScrollList<String>(mockScroll, list)
         emlScrolList.scroll(7)
@@ -135,11 +137,11 @@ internal class EmlScrollListTest {
 
     @Test
     fun Scrolling_beyond_list_start_stops_at_start() {
-        val list = mock(EmlList::class.java)
-        val mockScroll = mock(EmlScroll::class.java)
-        `when`(list.size).thenReturn(10)
-        `when`(list.selectedIndex).thenReturn(-20)
-        `when`(mockScroll.size).thenReturn(3)
+        val list: EmlList = mock()
+        val mockScroll: EmlScroll = mock()
+        whenever(list.size).thenReturn(10)
+        whenever(list.selectedIndex).thenReturn(-20)
+        whenever(mockScroll.size).thenReturn(3)
 
         val emlScrolList = EmlScrollList<String>(mockScroll, list)
         emlScrolList.scroll(-20)
@@ -149,11 +151,11 @@ internal class EmlScrollListTest {
 
     @Test
     fun Scrolling_beyond_list_end_stops_at_end() {
-        val list = mock(EmlList::class.java)
-        val mockScroll = mock(EmlScroll::class.java)
-        `when`(list.size).thenReturn(10)
-        `when`(list.selectedIndex).thenReturn(8)
-        `when`(mockScroll.size).thenReturn(3)
+        val list: EmlList = mock()
+        val mockScroll: EmlScroll = mock()
+        whenever(list.size).thenReturn(10)
+        whenever(list.selectedIndex).thenReturn(8)
+        whenever(mockScroll.size).thenReturn(3)
 
         val emlScrolList = EmlScrollList<String>(mockScroll, list)
         emlScrolList.scroll(20)

--- a/tests/src/com/github/emulio/ui/input/EmlScrollListTest.kt
+++ b/tests/src/com/github/emulio/ui/input/EmlScrollListTest.kt
@@ -1,0 +1,163 @@
+package com.github.emulio.ui.input
+
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+
+
+internal class EmlScrollListTest {
+
+    @Test
+    fun Scroll_by_zero_should_stay_at_same_index() {
+        val mockEmlList = mock(EmlList::class.java)
+        val emlScroll = mock(EmlScroll::class.java)
+        `when`(mockEmlList.size).thenReturn(7)
+        `when`(mockEmlList.selectedIndex).thenReturn(5)
+        `when`(emlScroll.size).thenReturn(3)
+        val emlScrolList = EmlScrollList<String>(emlScroll, mockEmlList)
+
+        emlScrolList.scroll(0)
+
+        verify(mockEmlList).selectedIndex = 5
+    }
+
+    @Test
+    fun Selecting_beyond_list_start_stops_at_start() {
+        val mockEmlList = mock(EmlList::class.java)
+        val emlScroll = mock(EmlScroll::class.java)
+        `when`(mockEmlList.size).thenReturn(7)
+        `when`(mockEmlList.selectedIndex).thenReturn(5)
+        `when`(emlScroll.size).thenReturn(3)
+        val emlScrolList = EmlScrollList<String>(emlScroll, mockEmlList)
+
+        emlScrolList.scroll(-20)
+
+        verify(mockEmlList).selectedIndex = 0
+    }
+
+    @Test
+    fun Selecting_beyond_list_end_stops_at_end() {
+        val mockEmlList = mock(EmlList::class.java)
+        val emlScroll = mock(EmlScroll::class.java)
+        `when`(mockEmlList.size).thenReturn(7)
+        `when`(mockEmlList.selectedIndex).thenReturn(5)
+        `when`(emlScroll.size).thenReturn(3)
+        val emlScrolList = EmlScrollList<String>(emlScroll, mockEmlList)
+
+        emlScrolList.scroll(20)
+
+        verify(mockEmlList).selectedIndex = 6
+    }
+
+    @Test
+    fun Scrolling_by_less_than_half_the_does_not_move_the_scroll() {
+        val list = mock(EmlList::class.java)
+        val mockScroll = mock(EmlScroll::class.java)
+        `when`(list.size).thenReturn(7)
+        `when`(list.selectedIndex).thenReturn(1)
+        `when`(mockScroll.size).thenReturn(3)
+        val emlScrolList = EmlScrollList<String>(mockScroll, list)
+
+        emlScrolList.scroll(1)
+
+        verify(mockScroll).setScrollTop(0)
+    }
+
+    @Test
+    fun Scrolling_by_more_than_half_the_scroll_size_moves_scroll() {
+        val list = mock(EmlList::class.java)
+        val mockScroll = mock(EmlScroll::class.java)
+        `when`(list.size).thenReturn(7)
+        `when`(list.selectedIndex).thenReturn(2)
+        `when`(mockScroll.size).thenReturn(3)
+
+        val emlScrolList = EmlScrollList<String>(mockScroll, list)
+        emlScrolList.scroll(2)
+
+        verify(mockScroll).setScrollTop(1)
+    }
+
+    @Test
+    fun Scrolling_to_the_middle_moves_the_scroll() {
+        val list = mock(EmlList::class.java)
+        val mockScroll = mock(EmlScroll::class.java)
+        `when`(list.size).thenReturn(7)
+        `when`(list.selectedIndex).thenReturn(4)
+        `when`(mockScroll.size).thenReturn(3)
+
+        val emlScrolList = EmlScrollList<String>(mockScroll, list)
+        emlScrolList.scroll(4)
+
+        verify(mockScroll).setScrollTop(3)
+    }
+
+    @Test
+    fun Scrolling_to_the_end_stops_the_scroll_at_the_end() {
+        val list = mock(EmlList::class.java)
+        val mockScroll = mock(EmlScroll::class.java)
+        `when`(list.size).thenReturn(7)
+        `when`(list.selectedIndex).thenReturn(7)
+        `when`(mockScroll.size).thenReturn(3)
+
+        val emlScrolList = EmlScrollList<String>(mockScroll, list)
+        emlScrolList.scroll(7)
+
+        verify(mockScroll).setScrollTop(4)
+    }
+
+    @Test
+    fun Empty_list_does_not_scroll() {
+        val list = mock(EmlList::class.java)
+        val mockScroll = mock(EmlScroll::class.java)
+        `when`(list.size).thenReturn(0)
+        `when`(list.selectedIndex).thenReturn(7)
+        `when`(mockScroll.size).thenReturn(3)
+
+        val emlScrolList = EmlScrollList<String>(mockScroll, list)
+        emlScrolList.scroll(7)
+
+        verify(mockScroll).setScrollTop(0)
+    }
+
+    @Test
+    fun Scroll_greater_than_list_does_not_scroll() {
+        val list = mock(EmlList::class.java)
+        val mockScroll = mock(EmlScroll::class.java)
+        `when`(list.size).thenReturn(10)
+        `when`(list.selectedIndex).thenReturn(8)
+        `when`(mockScroll.size).thenReturn(11)
+
+        val emlScrolList = EmlScrollList<String>(mockScroll, list)
+        emlScrolList.scroll(7)
+
+        verify(mockScroll).setScrollTop(0)
+    }
+
+
+    @Test
+    fun Scrolling_beyond_list_start_stops_at_start() {
+        val list = mock(EmlList::class.java)
+        val mockScroll = mock(EmlScroll::class.java)
+        `when`(list.size).thenReturn(10)
+        `when`(list.selectedIndex).thenReturn(-20)
+        `when`(mockScroll.size).thenReturn(3)
+
+        val emlScrolList = EmlScrollList<String>(mockScroll, list)
+        emlScrolList.scroll(-20)
+
+        verify(mockScroll).setScrollTop(0)
+    }
+
+    @Test
+    fun Scrolling_beyond_list_end_stops_at_end() {
+        val list = mock(EmlList::class.java)
+        val mockScroll = mock(EmlScroll::class.java)
+        `when`(list.size).thenReturn(10)
+        `when`(list.selectedIndex).thenReturn(8)
+        `when`(mockScroll.size).thenReturn(3)
+
+        val emlScrolList = EmlScrollList<String>(mockScroll, list)
+        emlScrolList.scroll(20)
+
+        verify(mockScroll).setScrollTop(7)
+    }
+}

--- a/tests/src/de/tomgrill/gdxtesting/GdxTestRunner.java
+++ b/tests/src/de/tomgrill/gdxtesting/GdxTestRunner.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright 2015 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package de.tomgrill.gdxtesting;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+
+import com.badlogic.gdx.ApplicationListener;
+import com.badlogic.gdx.backends.headless.HeadlessApplication;
+import com.badlogic.gdx.backends.headless.HeadlessApplicationConfiguration;
+
+public class GdxTestRunner extends BlockJUnit4ClassRunner implements ApplicationListener {
+
+	private Map<FrameworkMethod, RunNotifier> invokeInRender = new HashMap<FrameworkMethod, RunNotifier>();
+
+	public GdxTestRunner(Class<?> klass) throws InitializationError {
+		super(klass);
+		HeadlessApplicationConfiguration conf = new HeadlessApplicationConfiguration();
+
+		new HeadlessApplication(this, conf);
+	}
+
+	@Override
+	public void create() {
+	}
+
+	@Override
+	public void resume() {
+	}
+
+	@Override
+	public void render() {
+		synchronized (invokeInRender) {
+			for (Map.Entry<FrameworkMethod, RunNotifier> each : invokeInRender.entrySet()) {
+				super.runChild(each.getKey(), each.getValue());
+			}
+			invokeInRender.clear();
+		}
+	}
+
+	@Override
+	public void resize(int width, int height) {
+	}
+
+	@Override
+	public void pause() {
+	}
+
+	@Override
+	public void dispose() {
+	}
+
+	@Override
+	protected void runChild(FrameworkMethod method, RunNotifier notifier) {
+		synchronized (invokeInRender) {
+			invokeInRender.put(method, notifier);
+		}
+		waitUntilInvokedInRenderMethod();
+	}
+
+	private void waitUntilInvokedInRenderMethod() {
+		try {
+			while (true) {
+				Thread.sleep(10);
+				synchronized (invokeInRender) {
+					if (invokeInRender.isEmpty())
+						break;
+				}
+			}
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+	}
+
+}


### PR DESCRIPTION
Scraper screen has been refactored to stop managing scrolling and listing. EmlScrollList was created to make ScrollList reusable and maintainable. Applied dependency inversion through interfaces and covered it with unit tests to enhance maintainability.

